### PR TITLE
Fix permissions on index.php inside Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
 FROM php:7.2-apache
-COPY PHPinfoil.php /var/www/html/index.php
+COPY --chown=www-data PHPinfoil.php /var/www/html/index.php


### PR DESCRIPTION
The `index.php` file is owned by root and no accessible otherwise.